### PR TITLE
chore: update default CI workflows

### DIFF
--- a/.github/workflows/nightly-canary.yml
+++ b/.github/workflows/nightly-canary.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Run Noir tests
         run: nargo test
 
-      - name: Run formatter
-        run: nargo fmt --check
-
       - name: Alert on dead links
         uses: JasonEtco/create-an-issue@v2
         if: ${{ failure() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,26 @@ jobs:
 
       - name: Run formatter
         run: nargo fmt --check
+
+  # This is a job which depends on all test jobs and reports the overall status.
+  # This allows us to add/remove test jobs without having to update the required workflows.
+  tests-end:
+    name: Noir End
+    runs-on: ubuntu-latest
+    # We want this job to always run (even if the dependant jobs fail) as we want this job to fail rather than skipping.
+    if: ${{ always() }}
+    needs: 
+      - test
+      - format
+
+    steps:
+      - name: Report overall success
+        run: |
+          if [[ $FAIL == true ]]; then
+              exit 1
+          else
+              exit 0
+          fi
+        env:
+          # We treat any cancelled, skipped or failing jobs as a failure for the workflow as a whole.
+          FAIL: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}


### PR DESCRIPTION
# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds an end step to the noir test workflows to make required workflows robust against updating the noir version. I've also removed the formatter from the nightly canary to avoid killing the canary just when the formatter would make changes.

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
