### PR TITLE
chore: test on all stable noir versions greater than minimum supported version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,15 +8,36 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  MINIMUM_NOIR_VERSION: v0.34.0
 
 jobs:
+  noir-version-list:
+    name: Query supported Noir versions
+    runs-on: ubuntu-latest
+    outputs:
+      noir_versions: ${{ steps.get_versions.outputs.versions }}
+
+    steps:
+      - name: Checkout sources
+        id: get_versions
+        run: |         
+          # gh returns the Noir releases in reverse chronological order so we keep all releases published after the minimum supported version.
+          VERSIONS=$(gh release list -R noir-lang/noir --exclude-pre-releases --json tagName -q 'map(.tagName) | index(env.MINIMUM_NOIR_VERSION) as $index | if $index then .[0:$index+1] else [env.MINIMUM_NOIR_VERSION] end')
+          echo "versions=$VERSIONS"
+          echo "versions=$VERSIONS" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   test:
+    needs: [noir-version-list]
     name: Test on Nargo ${{matrix.toolchain}}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [nightly, 0.34.0]
+        toolchain: ${{ fromJson( needs.noir-version-list.outputs.noir_versions )}}
+        include:
+          - toolchain: nightly
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -38,7 +59,7 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 0.34.0
+          toolchain: ${{ env.MINIMUM_NOIR_VERSION }}
 
       - name: Run formatter
         run: nargo fmt --check


### PR DESCRIPTION
…

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR automates testing libraries on all the stable versions of Noir released since the minimum supported version.

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
