### PR TITLE
fix: Update CONTRIBUTING.md 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,6 @@ This guide will discuss how the team handles [Commits](#commits), [Pull Requests
 
 **Note:** We won't force external contributors to follow this verbatim, but following these guidelines definitely helps us in accepting your contributions.
 
-> [!NOTE]
-> Please tag @DeveloperRelations if you have any questions.
-
 ## Commits
 
 We want to keep our commits small and focused. This allows for easily reviewing individual commits and/or splitting up pull requests when they grow too big. Additionally, this allows us to merge smaller changes quicker.


### PR DESCRIPTION
# Description

Removes a note to tag the developer relations team, as this cannot be done by external contributors.

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
