### PR TITLE
fix: Update nargo and bb installations

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,6 +6,9 @@ on:
     - master
   pull_request:
 
+env:
+  MINIMUM_NOIR_VERSION: 1.0.0-beta.11
+
 jobs:
   test:
     name: Benchmark library
@@ -15,14 +18,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Nargo
-        uses: noir-lang/noirup@v0.1.3
+        uses: noir-lang/noirup@v0.1.4
         with:
-          toolchain: 0.36.0
+          toolchain: ${{env.MINIMUM_NOIR_VERSION}}
 
       - name: Install bb
         run: |
-          npm install -g bbup
-          bbup -nv 0.36.0
+          curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/next/barretenberg/bbup/install | bash
+          bbup -nv ${{env.MINIMUM_NOIR_VERSION}}
           sudo apt install libc++-dev
 
       - name: Build Noir benchmark programs


### PR DESCRIPTION
# Description

## Problem\*

For nargo installation:
- The version of noirup script used is a little old (v0.1.3 vs v0.1.4)
- The version of nargo used is quite old (v0.36.0 vs v1.0.0-beta.11)
- The version of nargo used is hard-coded at different places

For bb installation:
- The downloading of bbup relies on [bbup the NPM package](https://www.npmjs.com/package/bbup) rather than the raw GitHub source, which introduces additional supply attack chain vectors and is prone to falling out of date

## Summary\*

For nargo installation:
- Update to use v0.1.4 noirup
- Update to use Noir v1.0.0-beta.11
- Add and use an environmental variable for targetted Noir version

For bb installation:
- Switch to using https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/next/barretenberg/bbup/install for installing bbup instead 

# PR Checklist\*

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
